### PR TITLE
feat: add toast on auth success

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -42,6 +42,6 @@ jobs:
       - name: Build 🏗️
         run: yarn build
 
-      # TODO
+      # TODO: Add test to CI
       # - name: Test 🚨
       #   run: yarn test

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -7,6 +7,9 @@ import { useRouter } from 'next/router'
 // ** Config
 import authConfig from 'src/configs/auth'
 
+// ** Third Party Imports
+import toast from 'react-hot-toast'
+
 // ** Hooks
 import { useApi } from 'src/hooks/useApi'
 
@@ -99,7 +102,7 @@ const AuthProvider = ({ children }: Props) => {
 
         const redirectURL = returnUrl && returnUrl !== '/' ? returnUrl : '/'
 
-        // TODO: Toast success message
+        toast.success('Login succeed')
         router.replace(redirectURL as string)
 
         // Create axios instance with Bearer token
@@ -123,7 +126,7 @@ const AuthProvider = ({ children }: Props) => {
     $api.internal
       .register(params)
       .then(() => {
-        // TODO: Toast success message
+        toast.success('Register succeed')
         router.replace('/login')
       })
 

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -123,7 +123,6 @@ const LoginPage = () => {
   const onSubmit = (data: LoginRequestDto) => {
     const { email, password } = data
 
-    // TODO: Handle error message sent from BE
     auth.login({ email, password }, () => {
       setError('email', {
         type: 'manual',

--- a/src/pages/register/index.tsx
+++ b/src/pages/register/index.tsx
@@ -133,7 +133,6 @@ const Register = () => {
   const onSubmit = (data: RegisterRequestDto) => {
     const { email, name, password } = data
 
-    // TODO: Handle error message sent from BE
     auth.register({ email, name, password }, () => {
       setError('email', {
         type: 'manual',


### PR DESCRIPTION
## Why

Close #issue_number

## Changelog
Add toast message on login/register success

## Screenshots
<img width="229" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/a88e1466-c2e2-4ccc-815f-4d38b31407ce">

## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None

## Checklist

<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->

- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, Figma design spec, bug report, etc -->
- [x] Provided enough context in PR/issue description for reviewers.
