### PR TITLE
chore: add choose org button

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -5,7 +5,7 @@
     },
     "user_dropdown": {
         "profile": "Profile",
-        "inbox": "Inbox",
+        "organization": "Organizations",
         "chat": "Chat",
         "settings": "Settings",
         "pricing": "Pricing",

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -5,7 +5,7 @@
     },
     "user_dropdown": {
         "profile": "プロフィール",
-        "inbox": "受信箱",
+        "organization": "組織選択",
         "chat": "チャット",
         "settings": "設定",
         "pricing": "価格設定",

--- a/public/locales/vn.json
+++ b/public/locales/vn.json
@@ -5,7 +5,7 @@
     },
     "user_dropdown": {
         "profile": "Trang cá nhân",
-        "inbox": "Hộp thư",
+        "organization": "Chọn tổ chức",
         "chat": "Nhắn tin",
         "settings": "Cài đặt",
         "pricing": "Chiến lược giá",

--- a/src/@core/layouts/components/shared-components/UserDropdown.tsx
+++ b/src/@core/layouts/components/shared-components/UserDropdown.tsx
@@ -78,6 +78,10 @@ const UserDropdown = (props: Props) => {
     }
   }
 
+  const handleOrganization = () => {
+    router.replace('/organization')
+  }
+
   const handleLogout = () => {
     logout()
     handleDropdownClose()
@@ -137,10 +141,10 @@ const UserDropdown = (props: Props) => {
             {t('user_dropdown.profile')}
           </Box>
         </MenuItem>
-        <MenuItem sx={{ p: 0 }} onClick={() => handleDropdownClose()}>
+        <MenuItem sx={{ p: 0 }} onClick={handleOrganization}>
           <Box sx={styles}>
-            <Icon icon='mdi:email-outline' />
-            {t('user_dropdown.inbox')}
+            <Icon icon='mdi:office-building-outline' />
+            {t('user_dropdown.organization')}
           </Box>
         </MenuItem>
         <MenuItem sx={{ p: 0 }} onClick={() => handleDropdownClose()}>


### PR DESCRIPTION
## Why

Close #issue_number

## Changelog
Add button to navigate users to `/organization` choosing page

## Screenshots
<img width="238" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/82e4a332-c4e1-40e9-a702-42f5e5e56ccb">

None

## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None

## Checklist

<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->

- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, Figma design spec, bug report, etc -->
- [x] Provided enough context in PR/issue description for reviewers.
