### PR TITLE
chore: disabled checkbox if only one admin left

### DIFF
--- a/src/store/apps/user/index.ts
+++ b/src/store/apps/user/index.ts
@@ -34,13 +34,31 @@ export const fetchUser = createAsyncThunk('appUsers/fetchUser', async (params: D
 
 // ** Delete User
 
+// ** Fetch Admin counts
+export const fetchAdminCount = createAsyncThunk('appUsers/fetchAdminCount', async () => {
+  const organizationId = getOrgId()
+  const storedToken = getAccessToken()
+
+  const response = await new Api({
+    baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
+    timeout: 30 * 1000, // 30 seconds
+    headers: {
+      Authorization: `Bearer ${storedToken}`
+    }
+  }).internal.usersControllerCountAdmin(organizationId)
+
+  return response.data
+})
+
 export const appUsersSlice = createSlice({
   name: 'appUsers',
   initialState: {
     data: [] as OrganizationUserResponseDto[],
     total: 1,
     params: {},
-    allData: [] as OrganizationUserResponseDto[]
+    allData: [] as OrganizationUserResponseDto[],
+
+    totalAdmins: 0
   },
   reducers: {},
   extraReducers: builder => {
@@ -49,7 +67,10 @@ export const appUsersSlice = createSlice({
       state.total = action.payload.metadata.total
       state.params = action.payload.metadata.params
       state.allData = action.payload.metadata.allData
-    })
+    }),
+      builder.addCase(fetchAdminCount.fulfilled, (state, action) => {
+        state.totalAdmins = action.payload.totalAdmins
+      })
   }
 })
 

--- a/src/store/auth/permission/index.ts
+++ b/src/store/auth/permission/index.ts
@@ -1,0 +1,39 @@
+// ** Redux Imports
+import { createSlice, createAsyncThunk } from '@reduxjs/toolkit'
+
+// ** Types
+import { Api, CaslPermission } from 'src/__generated__/AccountifyAPI'
+
+// ** Utils
+import { getAccessToken, getOrgId } from 'src/utils/localStorage'
+
+// ** Fetch User permissions
+export const fetchPermissions = createAsyncThunk('authPermissions/fetchPermissions', async () => {
+  const organizationId = getOrgId()
+  const storedToken = getAccessToken()
+
+  const response = await new Api({
+    baseURL: process.env.NEXT_PUBLIC_API_ENDPOINT,
+    timeout: 30 * 1000, // 30 seconds
+    headers: {
+      Authorization: `Bearer ${storedToken}`
+    }
+  }).internal.getUserPermissions(organizationId)
+
+  return response.data
+})
+
+export const authPermissionsSlice = createSlice({
+  name: 'authPermissions',
+  initialState: {
+    data: [] as CaslPermission[]
+  },
+  reducers: {},
+  extraReducers: builder => {
+    builder.addCase(fetchPermissions.fulfilled, (state, action) => {
+      state.data = action.payload.permissions
+    })
+  }
+})
+
+export default authPermissionsSlice.reducer

--- a/src/utils/role.ts
+++ b/src/utils/role.ts
@@ -1,6 +1,18 @@
+import { UserRole } from 'src/__generated__/AccountifyAPI'
+
 export const MAX_ROLES_PER_USER = 5
 export const ADMIN_ROLE_ID = 1
 export const MEMBER_ROLE_ID = 2
+
+export const isAdmin = (roleOrRoles?: UserRole | UserRole[]): boolean => {
+  if (!roleOrRoles) return false
+
+  if (!Array.isArray(roleOrRoles)) {
+    return roleOrRoles.id === ADMIN_ROLE_ID
+  }
+
+  return roleOrRoles.some(role => role.id === ADMIN_ROLE_ID)
+}
 
 /**
  * A user must have at least one role out of: [Admin, Member]

--- a/src/views/apps/roles/Table.tsx
+++ b/src/views/apps/roles/Table.tsx
@@ -26,7 +26,7 @@ import CustomAvatar from 'src/@core/components/mui/avatar'
 import { getInitials } from 'src/@core/utils/get-initials'
 
 // ** Actions Imports
-import { fetchUser } from 'src/store/apps/user'
+import { fetchAdminCount, fetchUser } from 'src/store/apps/user'
 import { fetchRole } from 'src/store/apps/role'
 
 // ** Types Imports
@@ -146,8 +146,13 @@ const UserList = () => {
         query: value
       })
     )
+    dispatch(fetchAdminCount())
     dispatch(fetchRole())
   }, [dispatch, role, value])
+
+  const hasOnlyOneAdmin = (): boolean => {
+    return userStore.totalAdmins <= 1
+  }
 
   const handleFilter = useCallback((val: string) => {
     setValue(val)
@@ -220,6 +225,7 @@ const UserList = () => {
         allRoles={roleStore.data}
         selectedCheckbox={selectedCheckbox}
         setSelectedCheckbox={setSelectedCheckbox}
+        hasOnlyOneAdmin={hasOnlyOneAdmin}
       />
     </Grid>
   )

--- a/src/views/apps/roles/dialogs/DialogEditUserRole.tsx
+++ b/src/views/apps/roles/dialogs/DialogEditUserRole.tsx
@@ -17,7 +17,7 @@ import Icon from 'src/@core/components/icon'
 
 // ** Types Imports
 import { OrganizationUserResponseDto, RoleResponseDto } from 'src/__generated__/AccountifyAPI'
-import { areSelectedRolesValid, getRoleErrorMessageArgs } from 'src/utils/role'
+import { areSelectedRolesValid, getRoleErrorMessageArgs, isAdmin } from 'src/utils/role'
 import { useTranslation } from 'react-i18next'
 
 interface DialogEditUserRoleProps {
@@ -27,6 +27,7 @@ interface DialogEditUserRoleProps {
   allRoles: RoleResponseDto[]
   selectedCheckbox: string[]
   setSelectedCheckbox: (value: string[]) => void
+  hasOnlyOneAdmin: () => boolean
 }
 
 const Transition = forwardRef(function Transition(
@@ -38,10 +39,18 @@ const Transition = forwardRef(function Transition(
 
 const DialogEditUserRole = (props: DialogEditUserRoleProps) => {
   // ** Props
-  const { show, setShow, organizationUser, allRoles, selectedCheckbox, setSelectedCheckbox } = props
+  const { show, setShow, organizationUser, allRoles, selectedCheckbox, setSelectedCheckbox, hasOnlyOneAdmin } = props
 
   // ** Hooks
   const { t } = useTranslation()
+
+  const isUserOnlyAdmin = (): boolean => {
+    return hasOnlyOneAdmin() && isAdmin(organizationUser?.roles)
+  }
+
+  const isRoleDisabled = (role: RoleResponseDto): boolean => {
+    return isUserOnlyAdmin() && isAdmin(role)
+  }
 
   const maybeRoleError = (): string => {
     if (areSelectedRolesValid(selectedCheckbox.map(checkbox => parseInt(checkbox)))) return ''
@@ -104,6 +113,7 @@ const DialogEditUserRole = (props: DialogEditUserRoleProps) => {
                   id={item.id.toString()}
                   onChange={() => toggleRole(item.id.toString())}
                   checked={selectedCheckbox.includes(item.id.toString())}
+                  disabled={isRoleDisabled(item)}
                 />
               }
             />


### PR DESCRIPTION
## Why

Close #issue_number

## Changelog
- Disabled remove admin for a user if it is the last admin of an organization

## Screenshots
<img width="1189" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/273afb7c-9a09-46f3-b277-e4dbdb78be32">

## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None

## Checklist

<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->

- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, Figma design spec, bug report, etc -->
- [x] Provided enough context in PR/issue description for reviewers.
