### PR TITLE
chore: add tooltip for delete last admin

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -72,6 +72,7 @@
             "email": "Email",
             "role": "Role",
             "actions": "Actions",
+            "cannot_delete_last_admin": "Since this user is the only admin, this account cannot be deleted",
             "edit_user_role_dialog_title": "Edit User Role",
             "remove_user_dialog_title": "Remove User Confirmation",
             "remove_user_dialog_subtitle": "If this user does not belong to other organizations, it will be deleted."

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -72,6 +72,7 @@
             "email": "Eメール",
             "role": "ロール",
             "actions": "行動",
+            "cannot_delete_last_admin": "このユーザーは唯一の管理者であるため、このアカウントは削除できません",
             "edit_user_role_dialog_title": "ユーザーロールの編集",
             "remove_user_dialog_title": "ユーザー削除の確​​認",
             "remove_user_dialog_subtitle": "このユーザーが他の組織に属していない場合は削除されます。"

--- a/public/locales/vn.json
+++ b/public/locales/vn.json
@@ -72,6 +72,7 @@
             "email": "Email",
             "role": "Vai trò",
             "actions": "Hành động",
+            "cannot_delete_last_admin": "Vì người dùng này là quản trị viên duy nhất, nên tài khoản này không thể bị xóa",
             "edit_user_role_dialog_title": "Chỉnh sửa vai trò người dùng",
             "remove_user_dialog_title": "Xác nhận xóa người dùng",
             "remove_user_dialog_subtitle": "Nếu người dùng này không thuộc tổ chức khác thì tài khoản sẽ bị xóa."

--- a/src/views/apps/roles/Table.tsx
+++ b/src/views/apps/roles/Table.tsx
@@ -10,6 +10,7 @@ import Card from '@mui/material/Card'
 import Grid from '@mui/material/Grid'
 import IconButton from '@mui/material/IconButton'
 import Typography from '@mui/material/Typography'
+import Tooltip from '@mui/material/Tooltip'
 import { DataGrid, GridColDef } from '@mui/x-data-grid'
 import { SelectChangeEvent } from '@mui/material/Select'
 
@@ -245,16 +246,25 @@ const UserList = () => {
             </IconButton>
           )}
           {ability?.can('delete', 'user') && (
-            <IconButton
-              color='error'
-              disabled={isUserLastAdmin(row)}
-              onClick={() => {
-                setShowDialogDeleteUser(true)
-                setSelectedOrganizationUser(row)
-              }}
-            >
-              <Icon icon='mdi:delete-outline' fontSize={20} />
-            </IconButton>
+            <>
+              <IconButton
+                color='error'
+                disabled={isUserLastAdmin(row)}
+                onClick={() => {
+                  setShowDialogDeleteUser(true)
+                  setSelectedOrganizationUser(row)
+                }}
+              >
+                <Icon icon='mdi:delete-outline' fontSize={20} />
+              </IconButton>
+              {isUserLastAdmin(row) && (
+                <Tooltip placement='top' title={t('role_page.user.cannot_delete_last_admin')}>
+                  <Box sx={{ display: 'flex' }}>
+                    <Icon icon='mdi:information-outline' fontSize='1rem' />
+                  </Box>
+                </Tooltip>
+              )}
+            </>
           )}
         </Box>
       )


### PR DESCRIPTION
## Why

Close #issue_number

## Changelog
- Add tooltip to inform user cannot delete the last organization's admin

## Screenshots
<img width="342" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/35cbaf8c-12d0-4c69-a1e1-08c776504dba">

## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None

## Checklist

<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->

- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, Figma design spec, bug report, etc -->
- [x] Provided enough context in PR/issue description for reviewers.
