### PR TITLE
chore: add i18n to preview & print invoice

### DIFF
--- a/public/locales/en.json
+++ b/public/locales/en.json
@@ -149,7 +149,7 @@
             "quantity": "Quantity",
             "currency": "Currency",
             "name": "Name",
-            "note": "Note ...",
+            "note": "Note",
             "price": "Price",
             "add_item": "Add Item",
             "create_invoice": "Create Invoice"
@@ -162,11 +162,40 @@
             "quantity": "Quantity",
             "currency": "Currency",
             "name": "Name",
-            "note": "Note ...",
+            "note": "Note",
             "price": "Price",
             "add_item": "Add Item",
             "update_invoice": "Update Invoice",
             "preview": "Preview"
+        },
+        "preview": {
+            "invoice": "Invoice",
+            "date": "Date",
+            "item": "Item",
+            "type": "Type",
+            "quantity": "Quantity",
+            "currency": "Currency",
+            "name": "Name",
+            "note": "Note",
+            "price": "Price",
+            "send_invoice": "Send Invoice",
+            "download": "Download",
+            "print": "Print",
+            "total": "Total",
+            "update_invoice": "Update Invoice"
+        },
+        "print": {
+            "invoice_to": "Invoice To",
+            "invoice": "Invoice",
+            "date": "Date",
+            "item": "Item",
+            "type": "Type",
+            "quantity": "Quantity",
+            "currency": "Currency",
+            "name": "Name",
+            "note": "Note",
+            "price": "Price",
+            "total": "Total"
         }
     },
     "user_page": {

--- a/public/locales/ja.json
+++ b/public/locales/ja.json
@@ -149,7 +149,7 @@
             "quantity": "量",
             "currency": "通貨",
             "name": "名前",
-            "note": "メモ。。。",
+            "note": "メモ",
             "price": "価格",
             "add_item": "アイテムの追加",
             "create_invoice": "インヴォイスの作成"
@@ -162,11 +162,40 @@
             "quantity": "量",
             "currency": "通貨",
             "name": "名前",
-            "note": "メモ。。。",
+            "note": "メモ",
             "price": "価格",
             "add_item": "アイテムの追加",
             "update_invoice": "インヴォイスの編集",
             "preview": "プレビュー"
+        },
+        "preview": {
+            "invoice": "インヴォイス",
+            "date": "日付",
+            "item": "アイテム",
+            "type": "タイプ",
+            "quantity": "量",
+            "currency": "通貨",
+            "name": "名前",
+            "note": "メモ",
+            "price": "価格",
+            "send_invoice": "インヴォイスの送信",
+            "download": "ダウンロード",
+            "print": "印刷",
+            "total": "合計",
+            "update_invoice": "インヴォイスの編集"
+        },
+        "print": {
+            "invoice_to": "インヴォイス先",
+            "invoice": "インヴォイス",
+            "date": "日付",
+            "item": "アイテム",
+            "type": "タイプ",
+            "quantity": "量",
+            "currency": "通貨",
+            "name": "名前",
+            "note": "メモ",
+            "price": "価格",
+            "total": "合計"
         }
     },
     "user_page": {

--- a/public/locales/vn.json
+++ b/public/locales/vn.json
@@ -141,12 +141,12 @@
         "add": {
             "invoice": "Hoá đơn",
             "date": "Thời gian",
-            "item": "Hoá đơn",
+            "item": "Tên",
             "type": "Loại",
             "quantity": "Số lượng",
             "currency": "Tiền tệ",
             "name": "Tên",
-            "note": "Ghi chú ...",
+            "note": "Ghi chú",
             "price": "Giá",
             "add_item": "Thêm hoá đơn",
             "create_invoice": "Tạo hoá đơn"
@@ -154,16 +154,45 @@
         "edit": {
             "invoice": "Hoá đơn",
             "date": "Thời gian",
-            "item": "Hoá đơn",
+            "item": "Tên",
             "type": "Loại",
             "quantity": "Số lượng",
             "currency": "Tiền tệ",
             "name": "Tên",
-            "note": "Ghi chú ...",
+            "note": "Ghi chú",
             "price": "Giá",
             "add_item": "Thêm hoá đơn",
             "update_invoice": "Cập nhật hoá đơn",
             "preview": "Xem trước"
+        },
+        "preview": {
+            "invoice": "Hoá đơn",
+            "date": "Thời gian",
+            "item": "Tên",
+            "type": "Loại",
+            "quantity": "Số lượng",
+            "currency": "Tiền tệ",
+            "name": "Tên",
+            "note": "Ghi chú",
+            "price": "Đơn giá",
+            "send_invoice": "Gửi hoá đơn",
+            "download": "Tải xuống",
+            "print": "In",
+            "total": "Tổng cộng",
+            "update_invoice": "Cập nhật hoá đơn"
+        },
+        "print": {
+            "invoice_to": "Hoá đơn tới",
+            "invoice": "Hoá đơn",
+            "date": "Thời gian",
+            "item": "Tên",
+            "type": "Loại",
+            "quantity": "Số lượng",
+            "currency": "Tiền tệ",
+            "name": "Tên",
+            "note": "Ghi chú",
+            "price": "Đơn giá",
+            "total": "Tổng cộng"
         }
     },
     "autocomplete": {

--- a/src/views/apps/invoice/preview/PreviewActions.tsx
+++ b/src/views/apps/invoice/preview/PreviewActions.tsx
@@ -18,6 +18,9 @@ import { getInvoiceEditUrl, getInvoicePrintUrl } from 'src/utils/router/invoice'
 // ** Context Imports
 import { AbilityContext } from 'src/layouts/components/acl/Can'
 
+// ** Hooks Imports
+import { useTranslation } from 'react-i18next'
+
 interface Props {
   id: string | undefined
   toggleAddPaymentDrawer: () => void
@@ -27,6 +30,7 @@ interface Props {
 const PreviewActions = ({ id, toggleSendInvoiceDrawer, toggleAddPaymentDrawer }: Props) => {
   // ** Hooks
   const ability = useContext(AbilityContext)
+  const { t } = useTranslation()
 
   return (
     <Card>
@@ -38,10 +42,10 @@ const PreviewActions = ({ id, toggleSendInvoiceDrawer, toggleAddPaymentDrawer }:
           onClick={toggleSendInvoiceDrawer}
           startIcon={<Icon icon='mdi:send-outline' />}
         >
-          Send Invoice
+          {t('invoice_page.preview.send_invoice')}
         </Button>
         <Button fullWidth sx={{ mb: 3.5 }} color='secondary' variant='outlined'>
-          Download
+          {t('invoice_page.preview.download')}
         </Button>
         <Button
           fullWidth
@@ -52,7 +56,7 @@ const PreviewActions = ({ id, toggleSendInvoiceDrawer, toggleAddPaymentDrawer }:
           variant='outlined'
           href={getInvoicePrintUrl(id)}
         >
-          Print
+          {t('invoice_page.preview.print')}
         </Button>
         <Button
           fullWidth
@@ -63,7 +67,7 @@ const PreviewActions = ({ id, toggleSendInvoiceDrawer, toggleAddPaymentDrawer }:
           href={getInvoiceEditUrl(id)}
           disabled={!ability?.can('update', 'invoice')}
         >
-          Edit Invoice
+          {t('invoice_page.preview.update_invoice')}
         </Button>
         <Button
           fullWidth

--- a/src/views/apps/invoice/preview/PreviewCard.tsx
+++ b/src/views/apps/invoice/preview/PreviewCard.tsx
@@ -21,7 +21,12 @@ import { InvoiceResponseDto } from 'src/__generated__/AccountifyAPI'
 
 // ** Third Parties Imports
 import { format } from 'date-fns'
+
+// ** Utils Imports
 import { calculateInvoiceItemTotal } from 'src/utils/invoice'
+
+// ** Hooks Imports
+import { useTranslation } from 'react-i18next'
 
 interface Props {
   data: InvoiceResponseDto
@@ -47,6 +52,7 @@ const CalcWrapper = styled(Box)<BoxProps>(({ theme }) => ({
 const PreviewCard = ({ data }: Props) => {
   // ** Hook
   const theme = useTheme()
+  const { t } = useTranslation()
 
   if (data) {
     return (
@@ -126,11 +132,11 @@ const PreviewCard = ({ data }: Props) => {
             </Grid>
             <Grid item sm={6} xs={12}>
               <Box sx={{ display: 'flex', justifyContent: { xs: 'flex-start', sm: 'flex-end' } }}>
-                <Table sx={{ maxWidth: '200px' }}>
+                <Table sx={{ maxWidth: '250px' }}>
                   <TableBody>
                     <TableRow>
                       <MUITableCell>
-                        <Typography variant='h6'>Invoice</Typography>
+                        <Typography variant='h6'>{t('invoice_page.preview.invoice')}</Typography>
                       </MUITableCell>
                       <MUITableCell>
                         <Typography variant='h6'>{`#${data.id}`}</Typography>
@@ -138,7 +144,7 @@ const PreviewCard = ({ data }: Props) => {
                     </TableRow>
                     <TableRow>
                       <MUITableCell>
-                        <Typography variant='body2'>Date:</Typography>
+                        <Typography variant='body2'>{t('invoice_page.preview.date')}:</Typography>
                       </MUITableCell>
                       <MUITableCell>
                         <Typography variant='body2' sx={{ fontWeight: 600 }}>
@@ -159,10 +165,10 @@ const PreviewCard = ({ data }: Props) => {
           <Grid container>
             <Grid item xs={12} sm={6} sx={{ mb: { lg: 0, xs: 4 } }}>
               <Typography variant='body2' sx={{ mb: 3.5, fontWeight: 600 }}>
-                Name:
+                {t('invoice_page.preview.name')}:
               </Typography>
               <Typography variant='body2' sx={{ mb: 2 }}>
-                Invoice #{data.id}
+                {t('invoice_page.preview.invoice')} #{data.id}
               </Typography>
             </Grid>
           </Grid>
@@ -174,13 +180,13 @@ const PreviewCard = ({ data }: Props) => {
           <Table>
             <TableHead>
               <TableRow>
-                <TableCell>Item</TableCell>
-                <TableCell>Description</TableCell>
-                <TableCell>Type</TableCell>
-                <TableCell>Price</TableCell>
-                <TableCell>Qty</TableCell>
-                <TableCell>Currency</TableCell>
-                <TableCell>Total</TableCell>
+                <TableCell>{t('invoice_page.preview.item')}</TableCell>
+                <TableCell>{t('invoice_page.preview.note')}</TableCell>
+                <TableCell>{t('invoice_page.preview.type')}</TableCell>
+                <TableCell>{t('invoice_page.preview.price')}</TableCell>
+                <TableCell>{t('invoice_page.preview.quantity')}</TableCell>
+                <TableCell>{t('invoice_page.preview.currency')}</TableCell>
+                <TableCell>{t('invoice_page.preview.total')}</TableCell>
               </TableRow>
             </TableHead>
             <TableBody>
@@ -245,7 +251,7 @@ const PreviewCard = ({ data }: Props) => {
 
         <CardContent>
           <Typography variant='body2'>
-            <strong>Note:</strong> Note #{data.id}
+            <strong>{t('invoice_page.preview.note')}:</strong> Note #{data.id}
           </Typography>
         </CardContent>
       </Card>

--- a/src/views/apps/invoice/print/PrintPage.tsx
+++ b/src/views/apps/invoice/print/PrintPage.tsx
@@ -37,6 +37,9 @@ import themeConfig from 'src/configs/themeConfig'
 import { getInvoiceListUrl } from 'src/utils/router/invoice'
 import { calculateInvoiceItemTotal } from 'src/utils/invoice'
 
+// ** Hooks Imports
+import { useTranslation } from 'react-i18next'
+
 const CalcWrapper = styled(Box)<BoxProps>(({ theme }) => ({
   display: 'flex',
   alignItems: 'center',
@@ -53,6 +56,7 @@ export interface InvoicePrintProps {
 const InvoicePrint = ({ id }: InvoicePrintProps) => {
   // ** Hooks
   const theme = useTheme()
+  const { t } = useTranslation()
 
   // ** Store
   const dispatch = useDispatch<AppDispatch>()
@@ -157,11 +161,11 @@ const InvoicePrint = ({ id }: InvoicePrintProps) => {
           <Grid item xs={4}>
             <Box sx={{ display: 'flex', flexDirection: 'column', alignItems: { sm: 'flex-end', xs: 'flex-start' } }}>
               <Typography variant='h6' sx={{ mb: 2 }}>
-                {`Invoice #${invoice.id}`}
+                {`${t('invoice_page.print.invoice')} #${invoice.id}`}
               </Typography>
               <Box sx={{ display: 'flex' }}>
                 <Typography variant='body2' sx={{ mr: 3 }}>
-                  Date:
+                  {t('invoice_page.print.date')}:
                 </Typography>
                 <Typography variant='body2' sx={{ fontWeight: 600 }}>
                   {format(new Date(invoice?.date ? new Date(invoice.date) : new Date()), 'dd MMM yyyy')}
@@ -176,10 +180,10 @@ const InvoicePrint = ({ id }: InvoicePrintProps) => {
         <Grid container>
           <Grid item xs={7} md={8} sx={{ mb: { lg: 0, xs: 4 } }}>
             <Typography variant='body2' sx={{ mb: 3.5, fontWeight: 600 }}>
-              Invoice To:
+              {t('invoice_page.print.invoice_to')}:
             </Typography>
             <Typography variant='body2' sx={{ mb: 2 }}>
-              Invoice #{invoice.id}
+              {t('invoice_page.print.invoice')} #{invoice.id}
             </Typography>
           </Grid>
         </Grid>
@@ -189,13 +193,13 @@ const InvoicePrint = ({ id }: InvoicePrintProps) => {
         <Table sx={{ mb: 6 }}>
           <TableHead>
             <TableRow>
-              <TableCell>Item</TableCell>
-              <TableCell>Description</TableCell>
-              <TableCell>Type</TableCell>
-              <TableCell>Price</TableCell>
-              <TableCell>Qty</TableCell>
-              <TableCell>Currency</TableCell>
-              <TableCell>Total</TableCell>
+              <TableCell>{t('invoice_page.print.item')}</TableCell>
+              <TableCell>{t('invoice_page.print.note')}</TableCell>
+              <TableCell>{t('invoice_page.print.type')}</TableCell>
+              <TableCell>{t('invoice_page.print.price')}</TableCell>
+              <TableCell>{t('invoice_page.print.quantity')}</TableCell>
+              <TableCell>{t('invoice_page.print.currency')}</TableCell>
+              <TableCell>{t('invoice_page.print.total')}</TableCell>
             </TableRow>
           </TableHead>
           <TableBody>
@@ -255,8 +259,8 @@ const InvoicePrint = ({ id }: InvoicePrintProps) => {
 
         <Divider sx={{ my: `${theme.spacing(6)} !important` }} />
         <Typography variant='body2'>
-          <strong>Note:</strong> It was a pleasure working with you and your team. We hope you will keep us in mind for
-          future freelance projects. Thank You!
+          <strong>{t('invoice_page.print.note')}:</strong> It was a pleasure working with you and your team. We hope you
+          will keep us in mind for future freelance projects. Thank You!
         </Typography>
       </Box>
     )


### PR DESCRIPTION
## Why

Close #108 

## Changelog
- Add translation to preview/print invoice pages

## Screenshots
<img width="1499" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/0c66bd64-a844-4788-8b1b-177bafb209af">


## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None

## Checklist

<!-- Strive to complete the checklist. Remove those that do not apply to your PR -->

- [x] Confirmed that the PR resolves / follows the linked issue instructions. <!-- epic design spec, Figma design spec, bug report, etc -->
- [x] Provided enough context in PR/issue description for reviewers.
