### PR TITLE
chore: add year dropdown to project add datepicker

### DIFF
--- a/src/pages/[organization]/projects/add/index.tsx
+++ b/src/pages/[organization]/projects/add/index.tsx
@@ -210,6 +210,7 @@ const ProjectAdd = () => {
                   isClearable
                   selectsRange
                   monthsShown={2}
+                  showYearDropdown
                   endDate={endDateRange}
                   selected={startDateRange}
                   startDate={startDateRange}


### PR DESCRIPTION
## Why

Close #199 

## Changelog
- Each project always takes several years, so add a year dropdown to project add's datepicker to make it easier for user to select date

## Screenshots
<img width="600" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/30211124-d5bf-4a05-9dd8-331429ccab34">


## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None
