### PR TITLE
fix: ui broken when description too long

### DIFF
--- a/src/views/dashboards/analytics/OrganizationBudgetTracking.tsx
+++ b/src/views/dashboards/analytics/OrganizationBudgetTracking.tsx
@@ -4,6 +4,7 @@ import Link from 'next/link'
 // ** MUI Imports
 import Box from '@mui/material/Box'
 import Card from '@mui/material/Card'
+import Tooltip from '@mui/material/Tooltip'
 import Typography from '@mui/material/Typography'
 import CardHeader from '@mui/material/CardHeader'
 import CardContent from '@mui/material/CardContent'
@@ -72,18 +73,23 @@ const OrganizationBudgetTracking = ({ data }: OrganizationBudgetTrackingProps) =
                     sx={{
                       width: '100%',
                       display: 'flex',
-                      flexWrap: 'wrap',
-                      alignItems: 'center',
-                      justifyContent: 'space-between'
+                      flexWrap: 'nowrap',
+                      alignItems: 'flex-start',
+                      justifyContent: 'space-between',
+                      gap: '1rem'
                     }}
                   >
-                    <Box sx={{ mr: 2, display: 'flex', flexDirection: 'column' }}>
+                    <Box sx={{ mr: 2, display: 'flex', flexDirection: 'column', flex: 3 }}>
                       <Typography sx={{ mb: 0.25, fontWeight: 600, fontSize: '0.875rem' }}>
-                        <LinkStyled href={getProjectDefaultTab(project.id)}>{project.name}</LinkStyled>
+                        <LinkStyled href={getProjectDefaultTab(project.name)}>{project.name}</LinkStyled>
                       </Typography>
-                      <Typography variant='caption'>{project.description}</Typography>
+                      <Tooltip title={project.description}>
+                        <Typography variant='caption'>{`${project.description.slice(0, 50)} ${
+                          project.description.length < 50 ? '' : '...'
+                        }`}</Typography>
+                      </Tooltip>
                     </Box>
-                    <Box sx={{ width: '40%' }}>
+                    <Box sx={{ flex: 2 }}>
                       <Typography variant='body2'>
                         {calculateBudgetProcess(project.totalSpent, project.totalBudget)}%
                       </Typography>


### PR DESCRIPTION
## Why

Close #224 

## Changelog
- Fix UI broken when project description too long

## Screenshots
<img width="453" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/c689cdb3-dc16-4666-b3ab-0923bc314846">


## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None
