### PR TITLE
fix: align right invoice total

### DIFF
--- a/src/pages/[organization]/invoice/list/index.tsx
+++ b/src/pages/[organization]/invoice/list/index.tsx
@@ -268,7 +268,9 @@ const InvoiceList = () => {
           {row.type === InvoiceType.EXPENSE ? '-' : '+'}
           {formatCurrencyAsStandard(row.total, Locale.EN, row.currency)}
         </Typography>
-      )
+      ),
+      headerAlign: 'right',
+      align: 'right'
     },
     {
       flex: 0.2,

--- a/src/views/pages/project/invoice/index.tsx
+++ b/src/views/pages/project/invoice/index.tsx
@@ -261,7 +261,9 @@ const InvoiceTab = ({ projectId, name }: InvoiceTabProps) => {
           {row.type === InvoiceType.EXPENSE ? '-' : '+'}
           {formatCurrencyAsStandard(row.total, Locale.EN, row.currency)}
         </Typography>
-      )
+      ),
+      headerAlign: 'right',
+      align: 'right'
     },
     {
       flex: 0.2,


### PR DESCRIPTION
## Why

Close #241 

## Changelog
- Align right for invoice total column

## Screenshots
<img width="1510" alt="image" src="https://github.com/dylan751/sushi/assets/82252265/3feaccb1-a926-443a-bb21-47cbbb61c507">


## How to test this change in local

### Branches

- ramen: `develop` (or pr_link)
<!-- If it requires a specific branch other than develop for other services  -->
- other: `develop` (or pr_link)

### Others

<!-- As much detail as possible -->
<!-- Eg: Run yarn command:run sync-dynamodb-to-es -t AGGREGATION_BILLS in Iggre... -->

- None
